### PR TITLE
Update mainwindow.cpp

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -5,7 +5,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
     face_cascade_ = new QAction("Change Face Cascade", this);
     this->connect(face_cascade_, SIGNAL(triggered()), SLOT(change_face_cascade()));
 
-    auto cascade_file_menu = this->menuBar()->addMenu(tr("File"));
+    cascade_file_menu = this->menuBar()->addMenu(tr("File"));
     cascade_file_menu->addAction(face_cascade_);
 
     DisplayWidget* display = new DisplayWidget(this);


### PR DESCRIPTION
Deleting auto type for cascade_file_menu which is C++11, not always supported by Qt Creator (type changed to Qmenu* in mainWindow.h)